### PR TITLE
Fix Tensor Size Attribute: Replace .Size[] with .size()

### DIFF
--- a/src/torchsurv/metrics/auc.py
+++ b/src/torchsurv/metrics/auc.py
@@ -1248,7 +1248,7 @@ class Auc:
                 weight_new_time = (weight[mask])[sorted_unique_indices]
 
             # for time-dependent estimate, select those corresponding to new time
-            if estimate.ndim == 2 and estimate.Size[1] > 1:
+            if estimate.ndim == 2 and estimate.size(1) > 1:
                 estimate = estimate[:, sorted_unique_indices]
 
         return estimate, new_time, weight, weight_new_time


### PR DESCRIPTION
The current implementation uses .Size[] to access the dimensions of a tensor, which is not a valid operation in PyTorch. This results in an AttributeError: 'Tensor' object has no attribute 'Size'. 

To resolve this issue, the .Size[] attribute should be replaced with the correct .size() method.

Code to reproduce the issue and test the suggested hotfix:

```
import torch
from torchsurv.metrics.auc import Auc
from torchsurv.metrics.cindex import ConcordanceIndex
from torchsurv.loss.weibull import log_hazard

# Example usage
auc = Auc()
cindex = ConcordanceIndex()

survival_output = torch.randn(100, 2)  # Example tensor - Weibull's model output
event = torch.randint(0, 2, (100,))  # Example tensor
TTE = torch.abs(torch.randn(100) * 100)  # Example tensor with values from 0 to 100

# Convert the two-column Weibull's model output to log hazard
log_hazard = log_hazard(survival_output, TTE, all_times=True)

# Calculate AUC and C-index
auc_value = auc(log_hazard, event.bool(), TTE)
cindex_value = cindex(log_hazard, event.bool(), TTE)

print(f"Overall AUC: {auc_value.mean():.4f}")
print(f"Overall C-index: {cindex_value:.4f}")
```
