### PR TITLE
Fixed Size[] used on tensors (#96)

### DIFF
--- a/src/torchsurv/metrics/auc.py
+++ b/src/torchsurv/metrics/auc.py
@@ -1248,7 +1248,7 @@ class Auc:
                 weight_new_time = (weight[mask])[sorted_unique_indices]
 
             # for time-dependent estimate, select those corresponding to new time
-            if estimate.ndim == 2 and estimate.Size[1] > 1:
+            if estimate.ndim == 2 and estimate.size(1) > 1:
                 estimate = estimate[:, sorted_unique_indices]
 
         return estimate, new_time, weight, weight_new_time


### PR DESCRIPTION
The error AttributeError: 'Tensor' object has no attribute 'Size' is caused by the incorrect usage of Size[] instead of the correct method size().

