### PR TITLE
KM: For times beyond the train range, use the survival probability at…

### DIFF
--- a/docs/notebooks/introduction.ipynb
+++ b/docs/notebooks/introduction.ipynb
@@ -1233,7 +1233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "a0716ac7",
    "metadata": {},
    "outputs": [
@@ -1442,7 +1442,7 @@
    ],
    "source": [
     "# Print the survival values at each time step\n",
-    "km.print_survival_table()"
+    "km.get_survival_table()"
    ]
   }
  ],

--- a/src/torchsurv/metrics/auc.py
+++ b/src/torchsurv/metrics/auc.py
@@ -467,7 +467,7 @@ class Auc:
             >>> auc.p_value()  # Default: Blanche, two_sided
             tensor([0.1360, 0.7826, 0.4089])
             >>> auc.p_value(method="bootstrap", alternative="greater")
-            tensor([0.2400, 0.5800, 0.7380])
+            tensor([0.2400, 0.5910, 0.7430])
 
         """
 

--- a/src/torchsurv/metrics/auc.py
+++ b/src/torchsurv/metrics/auc.py
@@ -467,7 +467,7 @@ class Auc:
             >>> auc.p_value()  # Default: Blanche, two_sided
             tensor([0.1360, 0.7826, 0.4089])
             >>> auc.p_value(method="bootstrap", alternative="greater")
-            tensor([0.2400, 0.5910, 0.7430])
+            tensor([0.2400, 0.5800, 0.7380])
 
         """
 

--- a/src/torchsurv/stats/kaplan_meier.py
+++ b/src/torchsurv/stats/kaplan_meier.py
@@ -158,30 +158,29 @@ class KaplanMeierEstimator:
         # Ensure new_time is on the correct device
         new_time = new_time.to(self.device)
 
-        # add probability of 1 of survival before time 0
+        # Prepend baseline survival probability of 1 (at time 0 or before any event)
+        # and extend the reference time vector with -∞ to align indexing
         ref_time = torch.cat((-torch.tensor([torch.inf], device=self.device, dtype=self.time.dtype), self.time), dim=0)
         km_est_ = torch.cat((torch.ones(1, device=self.device, dtype=self.km_est.dtype), self.km_est))
 
-        # Check if newtime is beyond the last observed time point
+        # Identify time points in new_time that extend beyond the last train time in training
         extends = new_time > torch.max(ref_time)
-        if km_est_[torch.argmax(ref_time)] > 0 and extends.any():
-            # pylint: disable=consider-using-f-string
-            raise ValueError(
-                f"Cannot predict survival/censoring distribution after the largest observed training event time point: {ref_time[-1].item()}"
-            )
 
-        # beyond last time point is zero probability
+        # Initialize predicted survival probabilities
         km_pred = torch.zeros_like(new_time, dtype=km_est_.dtype, device=self.device)
-        km_pred[extends] = 0.0
 
-        # find new time points that match train time points
+        # For times beyond the train range, use the survival probability at the last train time
+        # (probability "holds" after the last event)
+        km_pred[extends] = km_est_[torch.argmax(ref_time)]
+
+        # For all other new_time points, locate their position relative to train times
         idx = torch.searchsorted(ref_time, new_time[~extends], side="left")
 
-        # For non-exact matches, take the left limit (shift the index to the left)
+        # If new_time does not exactly match an observed time, adjust index to take left limit
         eps = torch.finfo(ref_time.dtype).eps
         idx[torch.abs(ref_time[idx] - new_time[~extends]) >= eps] -= 1
 
-        # predict
+        # Assign survival estimates for in-range new_time points
         km_pred[~extends] = km_est_[idx]
 
         return km_pred

--- a/src/torchsurv/stats/kaplan_meier.py
+++ b/src/torchsurv/stats/kaplan_meier.py
@@ -2,8 +2,8 @@ import itertools
 import sys
 from typing import Tuple
 
-import torch
 import pandas as pd
+import torch
 
 from torchsurv.tools.validate_data import validate_survival_data
 
@@ -204,10 +204,7 @@ class KaplanMeierEstimator:
         for t, y in zip(self.time, self.km_est):
             print(f"{t:.2f}\t{y:.4f}")
 
-        return pd.DataFrame({
-                "Time": self.time.detach().cpu().numpy(),
-                "Survival": self.km_est.detach().cpu().numpy()
-            })
+        return pd.DataFrame({"Time": self.time.detach().cpu().numpy(), "Survival": self.km_est.detach().cpu().numpy()})
 
     def _compute_counts(
         self,

--- a/src/torchsurv/stats/kaplan_meier.py
+++ b/src/torchsurv/stats/kaplan_meier.py
@@ -3,6 +3,7 @@ import sys
 from typing import Tuple
 
 import torch
+import pandas as pd
 
 from torchsurv.tools.validate_data import validate_survival_data
 
@@ -185,7 +186,7 @@ class KaplanMeierEstimator:
 
         return km_pred
 
-    def print_survival_table(self):
+    def get_survival_table(self):
         """Prints the survival table with the unique times and Kaplan-Meier estimates.
 
         Examples:
@@ -202,6 +203,11 @@ class KaplanMeierEstimator:
         # Print unique times and Kaplan-Meier estimates
         for t, y in zip(self.time, self.km_est):
             print(f"{t:.2f}\t{y:.4f}")
+
+        return pd.DataFrame({
+                "Time": self.time.detach().cpu().numpy(),
+                "Survival": self.km_est.detach().cpu().numpy()
+            })
 
     def _compute_counts(
         self,

--- a/tests/test_kaplan_meier.py
+++ b/tests/test_kaplan_meier.py
@@ -211,7 +211,6 @@ class TestNonParametric(unittest.TestCase):
 
             self.assertRaises(ValueError, KaplanMeierEstimator(), train_event, train_time)
 
-
     def test_kaplan_meier_plot_km(self):
         """test Kaplan Meier plot function"""
         import matplotlib.pyplot as plt
@@ -246,6 +245,7 @@ class TestNonParametric(unittest.TestCase):
         # Use torch.allclose to allow for floating-point tolerance
         self.assertTrue(np.allclose(times, expected_times, atol=1e-4))
         self.assertTrue(np.allclose(survival, expected_survival, atol=1e-4))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Changes**
- To predict KM survival (censoring) probabilities at test times beyond the train range, use the survival (censoring) probability estimated at the last train time
- Change `km.print_survival_table()` to `km.get_survival_table()` to return the table and adjust testing accordingly

`bash dev/run-doctests.sh` and `bash dev/run-unittests.sh` run successfully. 

**Before changes**
```python
import torch
import numpy as np
from torchsurv.stats.ipcw import get_ipcw
from torchsurv.stats.kaplan_meier import KaplanMeierEstimator

_ = torch.manual_seed(44)
n = 5
event = torch.randint(low=0, high=2, size=(n,)).bool()
# tensor([False,  True,  True,  True,  True])
time = torch.randint(low=1, high=100, size=(n,)).float()
# tensor([37., 87.,  7., 56., 39.])
new_time = torch.randint(low=1, high=100, size=(n * 2,))
# tensor([21, 75, 34, 33, 99, 59,  3, 11, 15, 94])

get_ipcw(event, time)  # ipcw evaluated at time
# tensor([1.3333, 1.3333, 1.0000, 1.3333, 1.3333])
get_ipcw(event, time, new_time)  # ipcw evaluated at new_time
# ValueError: Cannot predict survival/censoring distribution after the largest observed training event time point: 87.0
```

**After changes**
```python
get_ipcw(event, time, new_time)  # ipcw evaluated at new_time
# tensor([1.0000, 1.3333, 1.0000, 1.0000, 1.3333, 1.3333, 1.0000, 1.0000, 1.0000,
#        1.3333])

```