### PR TITLE
Fix incorrect event indexing in Cox partial likelihood computation

### DIFF
--- a/src/torchsurv/loss/cox.py
+++ b/src/torchsurv/loss/cox.py
@@ -10,9 +10,6 @@ import torch
 from torchsurv.tools.validate_data import validate_model, validate_survival_data
 
 __all__ = [
-    # "_partial_likelihood_cox",
-    # "_partial_likelihood_efron",
-    # "_partial_likelihood_breslow",
     "neg_partial_log_likelihood",
     "baseline_survival_function",
     "survival_function",


### PR DESCRIPTION
First of all, thanks for creating and maintaining this repository!

I wanted to try it out and created a dummy dataset and a model with a single parameter, but did not get it to converge properly.

I think I found a bug in `_partial_likelihood_cox`. To my understanding, the variable `event_sorted` is a binary tensor. I think the correct operation is multiplication, not indexing. 